### PR TITLE
fix: prevent iframe from swallowing pointerup during panel resize

### DIFF
--- a/src/app/main-content.tsx
+++ b/src/app/main-content.tsx
@@ -32,6 +32,7 @@ interface MainContentProps {
 
 export function MainContent({ user, project }: MainContentProps) {
   const [activeView, setActiveView] = useState<"preview" | "code">("preview");
+  const [isDragging, setIsDragging] = useState(false);
 
   return (
     <FileSystemProvider initialData={project?.data}>
@@ -53,7 +54,7 @@ export function MainContent({ user, project }: MainContentProps) {
               </div>
             </ResizablePanel>
 
-            <ResizableHandle className="w-[1px] bg-neutral-200 hover:bg-neutral-300 transition-colors" />
+            <ResizableHandle className="w-[1px] bg-neutral-200 hover:bg-neutral-300 transition-colors" onDragging={setIsDragging} />
 
             {/* Right Panel - Preview/Code */}
             <ResizablePanel defaultSize={65}>
@@ -77,8 +78,9 @@ export function MainContent({ user, project }: MainContentProps) {
                 {/* Content Area */}
                 <div className="flex-1 overflow-hidden bg-blue-50">
                   {activeView === "preview" ? (
-                    <div className="h-full bg-white">
+                    <div className="h-full bg-white relative">
                       <PreviewFrame />
+                      {isDragging && <div className="absolute inset-0 z-10" />}
                     </div>
                   ) : (
                     <ResizablePanelGroup


### PR DESCRIPTION
When the user drags the panel divider over the preview iframe, react-resizable-panels never receives the pointerup event (it fires inside the iframe's document). This leaves dragState stuck, causing pointer-events:none to be applied to all panels — making the Preview/Code toggle tabs unresponsive until page refresh.

Fixes #2

Generated with [Claude Code](https://claude.ai/code)